### PR TITLE
#103 pass reset

### DIFF
--- a/src/modules/auth/controllers/changePassword.ts
+++ b/src/modules/auth/controllers/changePassword.ts
@@ -4,7 +4,7 @@ import { HttpStatus } from "../../common/enums/StatusCodes";
 import { validatePassword } from "../../common/utils/validatePassword";
 import { hashPassword } from "../../common/utils/hashPassword";
 
-export const changePassword = 
+const changePassword = 
   async (req: Request, res: Response): Promise<void> => {
     const { oldPassword, newPassword } = req.body;
 
@@ -51,3 +51,4 @@ export const changePassword =
     res.status(HttpStatus.Success).json({status: "success", message: "Password updated successfully" });
   }
 
+  export  default changePassword;

--- a/src/modules/auth/controllers/changePassword.ts
+++ b/src/modules/auth/controllers/changePassword.ts
@@ -1,0 +1,53 @@
+import { Request, Response } from "express";
+import { User, validatePasswordInput } from "../models/User"; 
+import { HttpStatus } from "../../common/enums/StatusCodes";
+import { validatePassword } from "../../common/utils/validatePassword";
+import { hashPassword } from "../../common/utils/hashPassword";
+
+export const changePassword = 
+  async (req: Request, res: Response): Promise<void> => {
+    const { oldPassword, newPassword } = req.body;
+
+    const userId = req.user?.id
+    if (!userId) {
+      res.status(HttpStatus.Unauthorized).json({status:"Bad request", message: "Unauthorized" });
+      return;
+    }
+
+   
+    const user = await User.findById(userId).exec();
+    if (!user) {
+      res.status(HttpStatus.NotFound).json({ status:"Bad request", message: "User not found" });
+      return;
+    }
+
+    //chack old password validity
+    const isMatch = await validatePassword(oldPassword, user.password);
+    if (!isMatch) {
+      res.status(HttpStatus.BadRequest).json({status:"Bad request", message: "Old password is incorrect" });
+      return;
+    }
+    //use new password to check old password validity
+    const ifNewisOld = await validatePassword(newPassword, user.password);
+    if(ifNewisOld) {
+      res.status(HttpStatus.BadRequest).json({status:"Bad request", message: "New password cannot be the same as the old password" });
+      return;
+    }
+
+    const {error} = validatePasswordInput(newPassword)
+    if(error){
+      res.status(HttpStatus.BadRequest).json({
+        status: "Bad request",
+        message: error.details[0].message,
+        statusCode: "400",
+      });
+      return;
+    }
+    const hashedNewPassword = await hashPassword(newPassword);
+
+    user.password = hashedNewPassword;
+    await user.save();
+
+    res.status(HttpStatus.Success).json({status: "success", message: "Password updated successfully" });
+  }
+

--- a/src/modules/auth/controllers/registerController.ts
+++ b/src/modules/auth/controllers/registerController.ts
@@ -49,7 +49,7 @@ const registerUser = asyncHandler(
       value: OTP,
       expires_at: otpExpiry,
     };
-    const result = await sendOTPEmail(email as string, OTP);
+    const result = await sendOTPEmail(email as string, OTP, "Your one-time Email verification code is:");
 
     res.status(HttpStatus.Created).json({
       status: "success",

--- a/src/modules/auth/controllers/reqResetPswd.ts
+++ b/src/modules/auth/controllers/reqResetPswd.ts
@@ -7,7 +7,7 @@ import sendOTPEmail from "../../common/utils/sendEmail";
 const TOKEN_EXPIRY_TIME = 2 * 60 * 1000; //2 mins
 
 
-export const requestPasswordReset = 
+const requestPasswordReset = 
   async (req: Request, res: Response): Promise<Response> => {
     const { email } = req.body;
 
@@ -24,8 +24,10 @@ export const requestPasswordReset =
 
     // Set token and expiry in session
     req.session.passwordReset = {
+      email,
       otp: resetOtp,
       expires_at: Date.now() + TOKEN_EXPIRY_TIME,
+      isVerified: false,
     };
 
     const message = `You requested a password reset. Your 6-digit token is:`;
@@ -43,3 +45,5 @@ export const requestPasswordReset =
     }
   }
 ;
+
+export default requestPasswordReset;

--- a/src/modules/auth/controllers/reqResetPswd.ts
+++ b/src/modules/auth/controllers/reqResetPswd.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from "express";
+import asyncHandler from "express-async-handler";
+import { User } from "../models/User";
+import sendEmail from "../../common/utils/sendEmail";
+import { HttpStatus } from "../../common/enums/StatusCodes";
+import { generateOtp } from "../../auth/utils/generateOtp";
+import sendOTPEmail from "../../common/utils/sendEmail";
+
+const TOKEN_EXPIRY_TIME = 2 * 60 * 1000; //2 mins
+
+
+export const requestPasswordReset = 
+  async (req: Request, res: Response): Promise<Response> => {
+    const { email } = req.body;
+
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(HttpStatus.NotFound).json({
+        status: "Not Found",
+        message: "User with this email does not exist",
+      });
+    }
+
+    // Generate 6-digit token
+    const resetOtp = await generateOtp()
+
+    // Set token and expiry in session
+    req.session.passwordReset = {
+      otp: resetOtp,
+      expires_at: Date.now() + TOKEN_EXPIRY_TIME,
+    };
+
+    const message = `You requested a password reset. Your 6-digit token is:`;
+    const result = await sendOTPEmail(email, resetOtp, message)
+    try {
+      return res.status(HttpStatus.Success).json({
+        status: "Success",
+        message: result,
+      });
+    } catch (error) {
+      return res.status(HttpStatus.ServerError).json({
+        status: "Error",
+        message: "Failed to send email. Try again later.",
+      });
+    }
+  }
+;

--- a/src/modules/auth/controllers/reqResetPswd.ts
+++ b/src/modules/auth/controllers/reqResetPswd.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
-import asyncHandler from "express-async-handler";
 import { User } from "../models/User";
-import sendEmail from "../../common/utils/sendEmail";
 import { HttpStatus } from "../../common/enums/StatusCodes";
 import { generateOtp } from "../../auth/utils/generateOtp";
 import sendOTPEmail from "../../common/utils/sendEmail";

--- a/src/modules/auth/controllers/resetPswd.ts
+++ b/src/modules/auth/controllers/resetPswd.ts
@@ -1,0 +1,58 @@
+import { Request, Response } from "express";
+import { User, validatePasswordInput } from "../models/User";
+import { hashPassword } from "../../common/utils/hashPassword";
+import { HttpStatus } from "../../common/enums/StatusCodes";
+
+ const resetPassword = 
+  async (req: Request, res: Response): Promise<Response> => {
+    const { newPassword } = req.body;
+
+
+    if (!req.session.passwordReset?.isVerified) {
+        return res.status(HttpStatus.Unauthorized).json({
+          status: "Unauthorized",
+          message: "You must verify the OTP before resetting your password",
+        });
+      }
+
+    const email = req.session.passwordReset?.email;
+    const user = await User.findOne({ email });
+
+    if (!user) {
+      return res.status(HttpStatus.NotFound).json({
+        status: "Not Found",
+        message: "User not found",
+      });
+    }
+    //checking for password strength
+    const {error} = validatePasswordInput(newPassword)
+    if(error){
+     return res.status(HttpStatus.BadRequest).json({
+        status: "Bad request",
+        message: error.details[0].message,
+        statusCode: "400",
+      });
+    }
+
+    //hashing/saving to db
+    user.password = await hashPassword(newPassword);
+    await user.save();
+
+    //destroy session
+    req.session.destroy((err) => {
+      if (err) {
+        return res.status(HttpStatus.ServerError).json({
+          status: "Error",
+          message: "Failed to destroy session",
+        });
+      }
+    });
+
+    return res.status(HttpStatus.Success).json({
+      status: "Success",
+      message: "Password has been reset successfully",
+    });
+  }
+;
+
+export default resetPassword;

--- a/src/modules/auth/controllers/verifyResetOtp.ts
+++ b/src/modules/auth/controllers/verifyResetOtp.ts
@@ -1,0 +1,36 @@
+import { Request, Response } from "express";
+import { HttpStatus } from "../../common/enums/StatusCodes";
+
+
+const verifyResetOtp = 
+  async (req: Request, res: Response): Promise<Response> => {
+    const { otp } = req.body;
+
+    const sessionOtp = req.session.passwordReset?.otp;
+    const expiredAt = req.session.passwordReset?.expires_at;
+    const currentTime = Date.now();
+
+    if (!sessionOtp || currentTime > expiredAt) {
+      return res.status(HttpStatus.BadRequest).json({
+        status: "Bad Request",
+        message: "OTP is invalid or has expired",
+      });
+    }
+
+    if (sessionOtp !== otp) {
+      return res.status(HttpStatus.BadRequest).json({
+        status: "Bad Request",
+        message: "OTP is incorrect",
+      });
+    }
+
+    req.session.passwordReset.isVerified = true;
+
+    return res.status(HttpStatus.Success).json({
+      status: "Success",
+      message: "OTP has been verified. You can now reset your password.",
+    });
+  }
+;
+
+export default verifyResetOtp

--- a/src/modules/auth/models/User.ts
+++ b/src/modules/auth/models/User.ts
@@ -34,6 +34,23 @@ export const validateRegisterInput = (data: any) => {
 
   return schema.validate(data);
 };
+export const validatePasswordInput = (data: any) => {
+  const schema = Joi.object({
+    password: Joi.string()
+      .pattern(new RegExp("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[A-Za-z\\d]{8,}$"))
+      .required()
+      .messages({
+        "string.pattern.base":
+          "Password must contain at least 1 uppercase letter, 1 lowercase letter, 1 digit, and be at least 8 characters long",
+      }),
+    // confirmPassword: Joi.string()
+    //   .valid(Joi.ref("password"))
+    //   .required()
+    //   .messages({ "any.only": "Passwords do not match" }),
+  });
+
+  return schema.validate(data);
+};
 export const validateLoginInput = (data: any) => {
   const schema = Joi.object({
     email: Joi.string().email({ minDomainSegments: 2 }),

--- a/src/modules/auth/routes/auth.routes.ts
+++ b/src/modules/auth/routes/auth.routes.ts
@@ -3,7 +3,9 @@ import registerUser from "../controllers/registerController";
 import loginUser from "../controllers/loginController";
 import verifyOtp from "../controllers/verifyOtp";
 import {refreshToken} from "../controllers/refreshToken";
-// import changePassword from "../controllers/changePassword";
+import changePassword from "../controllers/changePassword";
+import verifyUserAcces from "../../common/middlewares/verifyaccess";
+
 
 const router = Router();
 
@@ -12,6 +14,6 @@ router.post("/register", registerUser);
 router.post("/verify-otp", verifyOtp);
 router.post("/login", loginUser);
 router.post("/refresh-token", refreshToken);
-// router.post("/change-password", changePassword);
+router.post("/change-password", verifyUserAcces ,changePassword);
 
 export default router;

--- a/src/modules/auth/routes/auth.routes.ts
+++ b/src/modules/auth/routes/auth.routes.ts
@@ -5,6 +5,9 @@ import verifyOtp from "../controllers/verifyOtp";
 import {refreshToken} from "../controllers/refreshToken";
 import changePassword from "../controllers/changePassword";
 import verifyUserAcces from "../../common/middlewares/verifyaccess";
+import verifyResetOtp from "../../auth/controllers/verifyResetOtp";
+import resetPassword from "../../auth/controllers/resetPswd";
+import requestPasswordReset from "../../auth/controllers/reqResetPswd";
 
 
 const router = Router();
@@ -14,6 +17,11 @@ router.post("/register", registerUser);
 router.post("/verify-otp", verifyOtp);
 router.post("/login", loginUser);
 router.post("/refresh-token", refreshToken);
-router.post("/change-password", verifyUserAcces ,changePassword);
+router.use(verifyUserAcces)
+router.post("/change-password", changePassword);
+router.post("/request-password-reset", requestPasswordReset);
+router.post("/verify-reset-otp", verifyResetOtp);
+router.post("/reset-password",  resetPassword);
+
 
 export default router;

--- a/src/modules/common/middlewares/verifyaccess.ts
+++ b/src/modules/common/middlewares/verifyaccess.ts
@@ -1,7 +1,7 @@
     import { Request, Response, NextFunction } from "express";
-    import { User } from "../../auth/models/User";
     import { HttpStatus } from "../../common/enums/StatusCodes";
     import verifyToken from "../../common/utils/verifyToken";
+   
 
    const changePassword = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     
@@ -13,9 +13,8 @@
       }
     
       const token = HEADER.split(' ')[1];
-    
-  
       let decodedToken;
+
       try {
         decodedToken = verifyToken(token);
       } catch (error) {
@@ -29,14 +28,9 @@
         return;
       }
     
-     
-      const user = await User.findById(userId).exec();
-      if (!user) {
-        res.status(HttpStatus.NotFound).json({status:"Bad request", message: "User not found" });
-        return;
-      }
+      req.user = { id: userId };
+      next();
       //will add verification b y role too.
-      res.status(HttpStatus.Success).json({ message: "Password updated successfully" });
     };
     
     export default changePassword;

--- a/src/modules/common/middlewares/verifyaccess.ts
+++ b/src/modules/common/middlewares/verifyaccess.ts
@@ -3,7 +3,7 @@
     import verifyToken from "../../common/utils/verifyToken";
    
 
-   const changePassword = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+   const verifyUserAcces = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     
       const HEADER = req.headers.authorization || req.headers.Authorization;
     
@@ -33,7 +33,7 @@
       //will add verification b y role too.
     };
     
-    export default changePassword;
+    export default verifyUserAcces ;
     
 
       // Implement JWT verification logic here

--- a/src/modules/common/middlewares/verifyaccess.ts
+++ b/src/modules/common/middlewares/verifyaccess.ts
@@ -1,0 +1,48 @@
+    import { Request, Response, NextFunction } from "express";
+    import { User } from "../../auth/models/User";
+    import { HttpStatus } from "../../common/enums/StatusCodes";
+    import verifyToken from "../../common/utils/verifyToken";
+
+   const changePassword = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    
+      const HEADER = req.headers.authorization || req.headers.Authorization;
+    
+      if (typeof HEADER !== 'string' || !HEADER.startsWith('Bearer ')) {
+        res.status(HttpStatus.Unauthorized).json({ message: "Unauthorized: No token provided" });
+        return;
+      }
+    
+      const token = HEADER.split(' ')[1];
+    
+  
+      let decodedToken;
+      try {
+        decodedToken = verifyToken(token);
+      } catch (error) {
+        res.status(HttpStatus.Forbiddden).json({ status:"Bad request", message: "Forbidden: Invalid token" });
+        return;
+      }
+    
+      const userId = decodedToken.id;
+      if (!userId) {
+        res.status(HttpStatus.Unauthorized).json({status:"Bad request", message: "Unauthorized: Invalid user" });
+        return;
+      }
+    
+     
+      const user = await User.findById(userId).exec();
+      if (!user) {
+        res.status(HttpStatus.NotFound).json({status:"Bad request", message: "User not found" });
+        return;
+      }
+      //will add verification b y role too.
+      res.status(HttpStatus.Success).json({ message: "Password updated successfully" });
+    };
+    
+    export default changePassword;
+    
+
+      // Implement JWT verification logic here
+    // Check if the user is authenticated and has the required role
+    // If the user is authenticated and has the required role, call next() to proceed with the request
+    // If the user is not authenticated or does not have the required role, respond with an appropriate error message

--- a/src/modules/common/utils/genAccessToken.ts
+++ b/src/modules/common/utils/genAccessToken.ts
@@ -1,6 +1,6 @@
-import jwt from "jsonwebtoken";
+  import jwt from "jsonwebtoken";
 
-export const generateAccessToken = (userId: string): string => {
-  const secret = process.env.ACCESS_TOKEN_SECRET as string;
-  return jwt.sign({ id: userId }, secret, { expiresIn: "15m" });
-};
+  export const generateAccessToken = (userId: string): string => {
+    const secret = process.env.ACCESS_TOKEN_SECRET as string;
+    return jwt.sign({ id: userId }, secret, { expiresIn: "15m" });
+  };

--- a/src/modules/common/utils/sendEmail.ts
+++ b/src/modules/common/utils/sendEmail.ts
@@ -1,6 +1,6 @@
 import nodemailer from "nodemailer";
 
-const sendOTPEmail = async (email: string, token: string) => {
+const sendOTPEmail = async (email: string, token: string, message:string) => {
   try {
     let transporter = nodemailer.createTransport({
       service: "gmail",
@@ -16,14 +16,14 @@ const sendOTPEmail = async (email: string, token: string) => {
     
             <h1 style="color: #333;">Ecommerce</h1>
     
-            <p>Your one-time Email verification code is:</p>
+            <p>{message}</p>
     
             <h2 style="color: #333; font-size: 24px;">${token}</h2>
     
             <p>Copy the link and Paste it to verify the Email</p>
     
             <div style="margin-top: 20px;">
-                <p style="font-size: 14px; color: #666;">Developed by Kariebi</p>
+                <p style="font-size: 14px; color: #666;">ecommerce.fav.jb.com</p>
             </div>
         </body>
     </html>    

--- a/src/modules/common/utils/verifyToken.ts
+++ b/src/modules/common/utils/verifyToken.ts
@@ -1,0 +1,11 @@
+import jwt from "jsonwebtoken";
+
+const verifyToken = (token: string): any => {
+    try {
+      const secret = process.env.ACCESS_TOKEN_SECRET as string;
+      return jwt.verify(token, secret);
+    } catch (err) {
+      throw new Error('Invalid token');
+    }
+  };
+  export default verifyToken;

--- a/src/modules/interfaces/User.ts
+++ b/src/modules/interfaces/User.ts
@@ -14,3 +14,10 @@ export interface IUser extends Document {
   isVerified: boolean;
 }
 
+declare module "express-serve-static-core" {
+  interface Request {
+    user?: {
+      id?: string;
+    }
+  }
+}

--- a/src/modules/interfaces/session.ts
+++ b/src/modules/interfaces/session.ts
@@ -13,5 +13,9 @@ declare module "express-session" {
         value: string;
         expires_at: number;
       };
+      passwordReset:  {
+        otp: string;
+        expires_at: number;
+      };
     }
   }

--- a/src/modules/interfaces/session.ts
+++ b/src/modules/interfaces/session.ts
@@ -14,8 +14,10 @@ declare module "express-session" {
         expires_at: number;
       };
       passwordReset:  {
-        otp: string;
+        otp?: string;
         expires_at: number;
+        isVerified?: boolean;
+        email: string;
       };
     }
   }


### PR DESCRIPTION

**Title:**  
`feat-#103: Implement reset password and Reset OTP verification endpoints`

---

**Description:**  
This pull request introduces two key features related to password reset functionality:

1. **Reset Password Endpoint (`/auth/v1/reset-password`)**:  
   Allows users to reset their password using a valid OTP. After verifying the OTP, users can securely set a new password.

2. **Verify OTP for Password Reset (`/auth/v1/verify-reset-otp`)**:  
   Adds an additional layer of security by verifying the OTP before allowing the user to reset their password.

**Changes Made:**
- Added `resetPassword` controller to handle the logic for resetting the password.
- Integrated OTP verification for resetting the password using the session.
- Implemented password hashing and saving the new password in the database after OTP validation.

