### PR TITLE
Ft #115 createnew otp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "express": "^4.20.0",
         "express-async-errors": "^3.1.1",
         "express-async-handler": "^1.2.0",
+        "express-rate-limit": "^7.4.1",
         "express-session": "^1.18.0",
         "googleapis": "^144.0.0",
         "helmet": "^7.1.0",
@@ -1264,6 +1265,21 @@
       "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
       "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w==",
       "license": "MIT"
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.4.1.tgz",
+      "integrity": "sha512-KS3efpnpIDVIXopMc65EMbWbUht7qvTCdtCR2dD/IZmi9MIkopYESwyRqLgv8Pfu589+KqDqOdzJWW7AHoACeg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
+      }
     },
     "node_modules/express-session": {
       "version": "1.18.0",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,11 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-  "build": "tsc && copyfiles -u 4 src/modules/states/utils/nigeria.json dist/modules/states/utils && cp -r src/views dist/views",
-  "test": "echo \"Error: no test specified\" && exit 1",
-  "start": "node -r tsconfig-paths/register dist/app.js",
-  "start:dev": "nodemon ./src/app.ts"
-},
-
+    "build": "tsc && copyfiles -u 4 src/modules/states/utils/nigeria.json dist/modules/states/utils && cp -r src/views dist/views",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node -r tsconfig-paths/register dist/app.js",
+    "start:dev": "nodemon ./src/app.ts"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
@@ -44,6 +43,7 @@
     "express": "^4.20.0",
     "express-async-errors": "^3.1.1",
     "express-async-handler": "^1.2.0",
+    "express-rate-limit": "^7.4.1",
     "express-session": "^1.18.0",
     "googleapis": "^144.0.0",
     "helmet": "^7.1.0",

--- a/src/modules/auth/controllers/registerController.ts
+++ b/src/modules/auth/controllers/registerController.ts
@@ -7,7 +7,7 @@ import { generateOtp } from "../utils/generateOtp";
 import sendOTPEmail from "../../common/utils/sendEmail";
 import "../../interfaces/session"
 
-const OTP_EXPIRY_TIME = 5 * 60 * 1000;
+const OTP_EXPIRY_TIME = 1 * 60 * 1000;
 
 const registerUser = asyncHandler(
   async (req: Request, res: Response): Promise<void> => {

--- a/src/modules/auth/controllers/registerController.ts
+++ b/src/modules/auth/controllers/registerController.ts
@@ -5,14 +5,16 @@ import { validateRegisterInput } from "../models/User";
 import { HttpStatus } from "../../common/enums/StatusCodes";
 import { generateOtp } from "../utils/generateOtp";
 import sendOTPEmail from "../../common/utils/sendEmail";
-import "../../interfaces/session"
+import "../../interfaces/session";
+import { OTP_STATIC_VALUE } from "../../auth/static/otp.static";
 
-const OTP_EXPIRY_TIME = 1 * 60 * 1000;
+
 
 const registerUser = asyncHandler(
   async (req: Request, res: Response): Promise<void> => {
     const { firstname, lastname, state, email, password } = req.body;
     const { error } = validateRegisterInput(req.body);
+    const{OTP_EXPIRY_TIME} =OTP_STATIC_VALUE;
 
    
     if (error) {

--- a/src/modules/auth/controllers/sendNewregOtp.ts
+++ b/src/modules/auth/controllers/sendNewregOtp.ts
@@ -2,14 +2,17 @@ import { Response, Request } from "express";
 import { HttpStatus } from "../../common/enums/StatusCodes";
 import { generateOtp } from "../utils/generateOtp2";
 import sendOTPEmail from "../../common/utils/sendEmail";
+import { OTP_STATIC_VALUE } from "../../auth/static/otp.static";
 
 
-const OTP_EXPIRY_TIME = 1 * 60 * 1000;
+const OTP_EXPIRY_TIME = 4 * 60 * 1000;
 
 const newRegistrationOtp = async (
   req: Request,
   res: Response
 ): Promise<Response | undefined> => {
+  const{OTP_EXPIRY_TIME} =OTP_STATIC_VALUE;
+  
     try {
         
         if (!req.session.otp) {

--- a/src/modules/auth/controllers/sendNewregOtp.ts
+++ b/src/modules/auth/controllers/sendNewregOtp.ts
@@ -1,0 +1,54 @@
+import { Response, Request } from "express";
+import { HttpStatus } from "../../common/enums/StatusCodes";
+import { generateOtp } from "../utils/generateOtp2";
+import sendOTPEmail from "../../common/utils/sendEmail";
+
+
+const OTP_EXPIRY_TIME = 5 * 60 * 1000;
+
+const newRegistrationOtp = async (
+  req: Request,
+  res: Response
+): Promise<Response | undefined> => {
+    try {
+        
+        if (!req.session.otp) {
+            return res.status(HttpStatus.BadRequest).json({
+              status: "Bad request",
+              message: "OTP has not been generated or assigned. Please request a new OTP.",
+              statusCode: HttpStatus.BadRequest,
+            });
+          }
+          if (!req.session) {
+            res.locals.error = "Session not found for request";
+            return res
+              .status(HttpStatus.ServerError)
+              .json({ message: "No session found" });
+          }
+          const otpExpiry = Date.now() + OTP_EXPIRY_TIME;
+          const OTP = await generateOtp();
+          const { email} = req.session.user
+          req.session.otp = {
+            value: OTP,
+            expires_at: otpExpiry,
+          };
+          const result = await sendOTPEmail(email as string, OTP, "Your one-time Email verification code is:");
+
+
+          res.status(HttpStatus.Created).json({
+            status: "success",
+            message: result,
+            otp: OTP
+          });
+    } catch (error) {
+        return res.status(HttpStatus.ServerError).json({
+            status: "Bad request",
+            message: "Internal server error",
+            error: `${error} error`,
+            statusCode: HttpStatus.ServerError,
+          });
+    }
+};
+
+
+export default newRegistrationOtp;

--- a/src/modules/auth/controllers/sendNewregOtp.ts
+++ b/src/modules/auth/controllers/sendNewregOtp.ts
@@ -4,7 +4,7 @@ import { generateOtp } from "../utils/generateOtp2";
 import sendOTPEmail from "../../common/utils/sendEmail";
 
 
-const OTP_EXPIRY_TIME = 5 * 60 * 1000;
+const OTP_EXPIRY_TIME = 1 * 60 * 1000;
 
 const newRegistrationOtp = async (
   req: Request,
@@ -15,7 +15,7 @@ const newRegistrationOtp = async (
         if (!req.session.otp) {
             return res.status(HttpStatus.BadRequest).json({
               status: "Bad request",
-              message: "OTP has not been generated or assigned. Please request a new OTP.",
+              message: "OTP ERROR:  Please complete the registration process to receive an OTP.",
               statusCode: HttpStatus.BadRequest,
             });
           }
@@ -34,7 +34,8 @@ const newRegistrationOtp = async (
           };
           const result = await sendOTPEmail(email as string, OTP, "Your one-time Email verification code is:");
 
-
+          console.log(req.session);
+          
           res.status(HttpStatus.Created).json({
             status: "success",
             message: result,

--- a/src/modules/auth/models/User.ts
+++ b/src/modules/auth/models/User.ts
@@ -75,3 +75,16 @@ export const validateOtpInput = (data:string) => {
   return schema.validate(data);
 }
 export const User = mongoose.model<IUser>("User", userSchema);
+
+// const userSchema = new Schema<IUser>({
+//   firstname: { type: String, required: false },  // Optional for Google users
+//   lastname: { type: String, required: false },   // Optional for Google users
+//   state: { type: String, required: false },      // Optional for Google users
+//   email: { type: String, required: true, unique: true },
+//   password: { type: String, required: false },   // Optional for Google users
+//   isVerified: { type: Boolean, required: true, default: false },
+//   address: { type: String, required: false },
+//   googleId: { type: String, required: false },   // Google-specific field
+//   provider: { type: String, enum: ['local', 'google'], default: 'local' },  // To differentiate users
+// });
+

--- a/src/modules/auth/routes/auth.routes.ts
+++ b/src/modules/auth/routes/auth.routes.ts
@@ -14,17 +14,13 @@ import newRegistrationOtp from "../../auth/controllers/sendNewregOtp";
 
 
 const router = Router();
-
-// import refreshToken from "../controllers/refreshToken";
-// import changePassword from "../controllers/changePassword";
-
 router.use(otpSessionConfig);
 
 router.post("/register", registerUser);
 router.post("/verify-otp", verifyOtp);
 router.post("/login", loginUser);
 router.post("/refresh-token", refreshToken);
-router.post('/auth/v1/generate-otp', otpRateLimiter, newRegistrationOtp);
+router.post('/generate-otp', otpRateLimiter, newRegistrationOtp);
 
 router.use(verifyUserAcces)
 router.post("/change-password", changePassword);

--- a/src/modules/auth/routes/auth.routes.ts
+++ b/src/modules/auth/routes/auth.routes.ts
@@ -9,6 +9,8 @@ import verifyResetOtp from "../../auth/controllers/verifyResetOtp";
 import resetPassword from "../../auth/controllers/resetPswd";
 import requestPasswordReset from "../../auth/controllers/reqResetPswd";
 import otpSessionConfig from "../../common/config/otpSessionConfig";
+import { otpRateLimiter } from "../../auth/utils/limiter";
+import newRegistrationOtp from "../../auth/controllers/sendNewregOtp";
 
 
 const router = Router();
@@ -22,6 +24,8 @@ router.post("/register", registerUser);
 router.post("/verify-otp", verifyOtp);
 router.post("/login", loginUser);
 router.post("/refresh-token", refreshToken);
+router.post('/auth/v1/generate-otp', otpRateLimiter, newRegistrationOtp);
+
 router.use(verifyUserAcces)
 router.post("/change-password", changePassword);
 router.post("/request-password-reset", requestPasswordReset);

--- a/src/modules/auth/static/otp.static.ts
+++ b/src/modules/auth/static/otp.static.ts
@@ -1,0 +1,3 @@
+export const OTP_STATIC_VALUE = {
+  OTP_EXPIRY_TIME: 4 * 60 * 1000,
+};

--- a/src/modules/auth/utils/generateOtp2.ts
+++ b/src/modules/auth/utils/generateOtp2.ts
@@ -1,0 +1,12 @@
+import crypto from 'crypto';
+
+
+export const generateOtp = async (length = 6): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    crypto.randomBytes(length, (err, buffer) => {
+      if (err) reject(err);
+      const otp = buffer.toString('hex').slice(0, length).toUpperCase(); // Change to upper case if desired
+      resolve(otp);
+    });
+  });
+};

--- a/src/modules/auth/utils/generateOtp2.ts
+++ b/src/modules/auth/utils/generateOtp2.ts
@@ -1,11 +1,16 @@
 import crypto from 'crypto';
 
-
 export const generateOtp = async (length = 6): Promise<string> => {
   return new Promise((resolve, reject) => {
     crypto.randomBytes(length, (err, buffer) => {
       if (err) reject(err);
-      const otp = buffer.toString('hex').slice(0, length).toUpperCase(); // Change to upper case if desired
+
+      // Convert the random bytes into a number string, then slice to desired length
+      const otp = Array.from(buffer)
+        .map(byte => (byte % 10).toString()) // Keep only digits (0-9)
+        .join('')
+        .slice(0, length);
+
       resolve(otp);
     });
   });

--- a/src/modules/auth/utils/limiter.ts
+++ b/src/modules/auth/utils/limiter.ts
@@ -2,8 +2,8 @@ import { HttpStatus } from '../../common/enums/StatusCodes';
 import rateLimit from 'express-rate-limit';
 
 export const otpRateLimiter = rateLimit({
-    windowMs: 1 * 60 * 1000, // 1 minute
-    max: 5, // Limit each IP to 5 OTP requests per minute
+  windowMs: 4 * 60 * 1000, // 4  minutes
+  max: 3, // Limit each IP to 3 OTP requests per 5 minutes
     message: {
       status: "Too many requests",
       message: "Too many OTP requests from this IP, please try again later.",

--- a/src/modules/auth/utils/limiter.ts
+++ b/src/modules/auth/utils/limiter.ts
@@ -1,0 +1,12 @@
+import { HttpStatus } from '../../common/enums/StatusCodes';
+import rateLimit from 'express-rate-limit';
+
+export const otpRateLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 5, // Limit each IP to 5 OTP requests per minute
+    message: {
+      status: "Too many requests",
+      message: "Too many OTP requests from this IP, please try again later.",
+      statusCode: HttpStatus.TooManyRequests
+    },
+  });

--- a/src/modules/common/enums/StatusCodes.ts
+++ b/src/modules/common/enums/StatusCodes.ts
@@ -8,4 +8,5 @@ export enum HttpStatus {
   NotFound = 404,
   Forbiddden = 403,
   ServerError = 500,
+  TooManyRequests = 429
 }

--- a/src/modules/interfaces/session.ts
+++ b/src/modules/interfaces/session.ts
@@ -24,17 +24,3 @@ declare module "express-session" {
   }
 
 
-// declare module "express-session" {
-//   interface Session {
-//     user: {
-//       id: string;
-//       firstname: string;
-//       lastname: string;
-//       state: string;
-//       email: string;
-//       password: string;
-     
-//     };
-//     otp: string;
-//   }
-// }


### PR DESCRIPTION

### **PR Title**:  
`ft-#115-create-new-otp: Implement New OTP Generation`

---

### **Description**:
- Added `/auth/v1/generate-otp` endpoint for generating a new OTP.
- Validates session and re-generates OTP if user data exists.
- Integrated rate limiting (3 requests per 4 minutes).
- Sends OTP via email and updates expiration.

---

### **Changes**:
- Added `newRegistrationOtp` controller for OTP generation.
- Updated session OTP logic.
- Integrated `generateOtp` and `sendOTPEmail` utilities.

---

### **Status**:
- Ready for review

---